### PR TITLE
Convert value to bigint before passing to viem

### DIFF
--- a/src/createWallet.ts
+++ b/src/createWallet.ts
@@ -78,7 +78,7 @@ export function createWallet(
         return await client.sendTransaction({
           to: (params?.[0] as any).to,
           data: (params?.[0] as any).data,
-          value: (params?.[0] as any).value,
+          value: (params?.[0] as any).value ? bigint((params?.[0] as any).value) : undefined,
           // Let viem handle the gas calcutation
           // gas: (params?.[0] as any).gas ?? (params?.[0] as any).gasLimit,
           // gasPrice: (params?.[0] as any).gasPrice,


### PR DESCRIPTION
Without converting to a BigInt, this will fail with custom `value` parameters as they are often converted to hexadecimal format before being passed to `sendTransaction`. In such a case, viem will not properly compute the value, and it will throw an "Insufficient funds" error claiming that the account does not have enough funds to cover `gas * price + value`.